### PR TITLE
support fixing npm workspace dependencies

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -19,7 +19,7 @@ def main():
     # Loop over each package in the packages section of the lockfile
     for package_key in lockfile['packages']:
         # Ignore the empty key & local packages
-        if package_key == "" or not package_key.startswith("node_modules/"):
+        if package_key == "" or not "node_modules/" in package_key:
             continue
 
         package = lockfile['packages'][package_key]


### PR DESCRIPTION
Found a case that my previous chanegs #2 don't cover.
That is dependencies of workspace packages, e.g. with a key like `packages/protoplugin/node_modules/typescript`.